### PR TITLE
fix: don't loop when matches is empty

### DIFF
--- a/lib/material_design_icons_flutter.dart
+++ b/lib/material_design_icons_flutter.dart
@@ -4603,6 +4603,7 @@ class MdiIcons {
   static toCamelCase(String str) {
     RegExp exp = new RegExp(r"[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+");
     Iterable<Match> matches = exp.allMatches(str);
+    if (matches.isEmpty) return '';
     String res = '';
     for (Match m in matches) {
       String match = m.group(0);


### PR DESCRIPTION
Hi,

I've got an error on `MdiIcons.fromString` when `Iterable<Match> matches = exp.allMatches(str);` in `MdiIcons.toCamelCase` match nothing because `for (Match m in matches)` has an empty `Iterable`.
Let me know if you have requests.

Thanks