### PR TITLE
Get close icons from string

### DIFF
--- a/lib/material_design_icons_flutter.dart
+++ b/lib/material_design_icons_flutter.dart
@@ -8155,8 +8155,8 @@ class MdiIcons {
   }
   
   static IconData? fromStringToCloseIcon(String key) {
-    final closeIcon = iconMap.keys.toList().firstWhere((icon)=>icon.contains(key));
-    return closeIcon != null ? iconMap[closeIcon] : iconMap['crop-square']
+    final closeIcon = iconMap.keys.firstWhere((icon)=>icon.contains(key),orElse: () => 'crop-square');
+    return iconMap[closeIcon]
   }
 
   IconData? operator [](String key) {

--- a/lib/material_design_icons_flutter.dart
+++ b/lib/material_design_icons_flutter.dart
@@ -8153,6 +8153,11 @@ class MdiIcons {
     final iconName = MdiIcons.toCamelCase(key);
     return iconMap[iconName];
   }
+  
+  static IconData? fromStringToCloseIcon(String key) {
+    final closeIcon = iconMap.keys.toList().firstWhere((icon)=>icon.contains(key));
+    return closeIcon != null ? iconMap[closeIcon] : iconMap['crop-square']
+  }
 
   IconData? operator [](String key) {
     final iconName = MdiIcons.toCamelCase(key);

--- a/lib/material_design_icons_flutter.dart
+++ b/lib/material_design_icons_flutter.dart
@@ -8156,7 +8156,7 @@ class MdiIcons {
   
   static IconData? fromStringToCloseIcon(String key) {
     final closeIcon = iconMap.keys.firstWhere((icon)=>icon.contains(key),orElse: () => 'crop-square');
-    return iconMap[closeIcon]
+    return iconMap[closeIcon];
   }
 
   IconData? operator [](String key) {


### PR DESCRIPTION
Not so many changes, just a function that takes a string and return an approximate icon.

I'd be happy to develop the idea.

### Problem idea : 

I'm making a list of user preferences which can be added manually from the user, but he is allowed only to write the preference (cannot pick an icon), so what if i take that preference text and estimate an icon for that ?.

### Result :

![image](https://github.com/ziofat/material_design_icons_flutter/assets/47502752/af78f754-7c0f-4a67-9c21-369adc7bcbd1)
